### PR TITLE
Implement python matchmaker through kafka message streaming

### DIFF
--- a/Server/build.gradle.kts
+++ b/Server/build.gradle.kts
@@ -58,6 +58,12 @@ dependencies {
      * PostgreSQL JDBC driver
      */
     implementation("org.postgresql:postgresql:42.7.5")
+
+    /**
+     * Kafka messaging library
+     */
+    implementation("org.apache.kafka:kafka-clients:4.0.0")
+
     /**
      * Testcontainers - Create docker containers for needed dependencies during test runtime
      */

--- a/Server/src/main/kotlin/org/readutf/matchmaker/matchmaker/impl/python/PythonMatchmaker.kt
+++ b/Server/src/main/kotlin/org/readutf/matchmaker/matchmaker/impl/python/PythonMatchmaker.kt
@@ -1,0 +1,135 @@
+package org.readutf.matchmaker.matchmaker.impl.python
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.github.michaelbull.result.onFailure
+import com.github.michaelbull.result.onSuccess
+import com.github.michaelbull.result.runCatching
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.readutf.matchmaker.Application
+import org.readutf.matchmaker.matchmaker.MatchMakerResult
+import org.readutf.matchmaker.matchmaker.PooledMatchmaker
+import org.readutf.matchmaker.queue.QueueTeam
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+
+open class PythonMatchmaker(
+    type: String,
+    name: String,
+    private val topic: String,
+) : PooledMatchmaker(type, name) {
+    private val logger = KotlinLogging.logger { }
+
+    private val requestFutures = mutableMapOf<UUID, CompletableFuture<PythonResult>>()
+
+    private val consumerSettings =
+        mapOf(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to "localhost:29092",
+            ConsumerConfig.GROUP_ID_CONFIG to "test-group",
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to "org.apache.kafka.common.serialization.StringDeserializer",
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to "org.apache.kafka.common.serialization.StringDeserializer",
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "latest",
+        )
+
+    private var producerSettings: Map<String, Any> =
+        mapOf(
+            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to "localhost:29092",
+            ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to "org.apache.kafka.common.serialization.StringSerializer",
+            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to "org.apache.kafka.common.serialization.StringSerializer",
+        )
+
+    private val producer = KafkaProducer<String, String>(producerSettings)
+    private val consumer =
+        KafkaConsumer<String, String>(consumerSettings).also {
+            it.subscribe(listOf("result_channel"))
+        }
+
+    init {
+        Thread {
+            while (true) {
+                println("Listening for messages...")
+
+                val records = consumer.poll(Duration.of(1, ChronoUnit.SECONDS))
+                for (record in records) {
+                    try {
+                        val pythonResult = Application.objectMapper.readValue(record.value(), PythonResult::class.java)
+                        requestFutures[UUID.fromString(pythonResult.requestId)]?.complete(pythonResult)
+                    } catch (e: Exception) {
+                        logger.error(e) { "Received an invalid message from kafka channel" }
+                    }
+                }
+            }
+        }.start()
+    }
+
+    override fun matchmake(teams: List<QueueTeam>): MatchMakerResult {
+        val teamMap = teams.associateBy { it.teamId }
+
+        val teamData =
+            teams.map { team ->
+                val attributes =
+                    Application.objectMapper.treeToValue(
+                        team.attributes,
+                        object : TypeReference<HashMap<String, Any>>() {},
+                    )
+                attributes["id"] = team.teamId.toString()
+                attributes
+            }
+
+        val requestId = UUID.randomUUID()
+
+        val request =
+            mapOf(
+                "requestId" to requestId.toString(),
+                "teams" to teamData,
+            )
+
+        val json = Application.objectMapper.writeValueAsString(request)
+
+        runCatching {
+            producer
+                .send(
+                    ProducerRecord(topic, "data", json),
+                ).get()
+        }.onFailure {
+            it.printStackTrace()
+        }.onSuccess { metadata ->
+            println("Sent to topic ${metadata.topic()} partition ${metadata.partition()} offset ${metadata.offset()}%n")
+        }
+
+        producer.flush()
+
+        val future = CompletableFuture<PythonResult>()
+        requestFutures[requestId] = future
+
+        val result =
+            try {
+                val result = future.get(3, TimeUnit.SECONDS)
+                val queueTeams = result.teams.map { team -> team.map { teamId -> teamMap[teamId]!! } }
+
+                MatchMakerResult.MatchMakerSuccess(queueTeams)
+            } catch (e: ExecutionException) {
+                MatchMakerResult.MatchMakerFailure(e)
+            }
+
+        return result
+    }
+
+    data class PythonResult(
+        val requestId: String,
+        val teams: List<List<UUID>>,
+    )
+
+    override fun shutdown() {
+        println("Shutting down PythonMatchmaker...")
+        producer.close()
+    }
+}

--- a/Server/src/test/kotlin/org/readutf/matchmaker/tests/PythonMatchmakerTest.kt
+++ b/Server/src/test/kotlin/org/readutf/matchmaker/tests/PythonMatchmakerTest.kt
@@ -1,0 +1,80 @@
+package org.readutf.matchmaker.tests
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.util.UUID
+import org.readutf.matchmaker.matchmaker.Matchmaker
+import org.readutf.matchmaker.matchmaker.impl.python.PythonMatchmaker
+import org.readutf.matchmaker.queue.QueueTeam
+import org.testng.annotations.AfterTest
+import org.testng.annotations.Test
+
+class PythonMatchmakerTest {
+
+    private val objectMapper = ObjectMapper()
+    private val matchmaker: Matchmaker = PythonMatchmaker("python", "test", "py-matchmaker-test")
+
+
+    @Test
+    fun pythonMatchmakerTest() {
+
+        matchmaker.addTeam(
+            QueueTeam(
+                teamId = UUID.randomUUID(),
+                socketId = "",
+                players = listOf(UUID.randomUUID()),
+                attributes = objectMapper.valueToTree(
+                    mapOf(
+                        "id" to "bd524747-d311-4a2a-b746-7178cc422ff4",
+                        "lifetime_level" to 71.0,
+                        "lifetime_kd" to 0.82,
+                        "lifetime_kills" to 640.0,
+                        "lifetime_deaths" to 779.0,
+                        "lifetime_kills_per_match" to 3.32,
+                        "lifetime_headshot_pct" to 34.91,
+                        "lifetime_matches_won" to 104.0,
+                        "lifetime_matches_lost" to 89.0,
+                        "lifetime_matches_abandoned" to 0.0,
+                        "lifetime_matches_played" to 193.0,
+                        "lifetime_match_win_pct" to 53.89,
+                        "lifetime_time_played" to 303209.0
+                    )
+                )
+            )
+        )
+        matchmaker.addTeam(
+            QueueTeam(
+                teamId = UUID.randomUUID(),
+                socketId = "",
+                players = listOf(UUID.randomUUID()),
+                attributes = objectMapper.valueToTree(
+                    mapOf(
+                        "id" to "0f3f1cf2-4329-49be-9215-10295819ac6c",
+                        "lifetime_level" to 319.0,
+                        "lifetime_kd" to 1.18,
+                        "lifetime_kills" to 30575.0,
+                        "lifetime_deaths" to 26014.0,
+                        "lifetime_kills_per_match" to 4.19,
+                        "lifetime_headshot_pct" to 51.13,
+                        "lifetime_matches_won" to 3780.0,
+                        "lifetime_matches_lost" to 3430.0,
+                        "lifetime_matches_abandoned" to 53.0,
+                        "lifetime_matches_played" to 7289.0,
+                        "lifetime_match_win_pct" to 51.86,
+                        "lifetime_time_played" to 10674049.0
+                    )
+                )
+            )
+        )
+
+        for (i in 0 until 5) {
+            matchmaker.matchmake()
+        }
+    }
+
+    @AfterTest
+    fun shutdown() {
+        matchmaker.shutdown()
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a Kafka-based Python matchmaker implementation and integrates it into the project. It includes updates to the build configuration, a new matchmaker class, and corresponding unit tests.

### Kafka Integration and Matchmaker Implementation:
* Added the Kafka messaging library dependency (`org.apache.kafka:kafka-clients:4.0.0`) to `Server/build.gradle.kts`.
* Implemented a new `PythonMatchmaker` class in `PythonMatchmaker.kt`, which uses Kafka for communication. This class includes producer and consumer configurations, message handling, and a `matchmake` method for matchmaking logic.

### Unit Testing for PythonMatchmaker:
* Created a new test class `PythonMatchmakerTest` in `PythonMatchmakerTest.kt`. This test validates the functionality of the `PythonMatchmaker` by simulating teams and invoking the matchmaking process.